### PR TITLE
Bug: Cart resource has duplicate line items #24: FIXED

### DIFF
--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -184,7 +184,6 @@ class Profile(ViewSet):
                 cart = {}
                 cart["order"] = OrderSerializer(open_order, many=False, context={
                                                 'request': request}).data
-                cart["order"]["line_items"] = line_items.data
                 cart["order"]["size"] = len(line_items.data)
 
             except Order.DoesNotExist as ex:


### PR DESCRIPTION
## Changes

Modified `views/profile.py` @action cart.  Removed line 187 (which added line_items a second time to the cart)

## Testing

- [ ] Run migrations
- [ ] Run test suite
- [ ] Seed database
- [ ] Run server
- [ ] GET Shopping Cart
- [ ] If test succeeds, GET request will return 200 and the following body:
{
    "id": 2,
    "url": "http://localhost:8000/orders/2",
    "created_date": "2019-04-12",
    "payment_type": null,
    "customer": "http://localhost:8000/customers/7",
    "lineitems": [
        {
            "id": 4,
            "product": {
                "id": 52,
                "name": "900",
                "price": 1296.98,
                "number_sold": 0,
                "description": "1987 Saab",
                "quantity": 2,
                "created_date": "2019-03-19",
                "location": "Vratsa",
                "image_path": null,
                "average_rating": 0
            }
        },
        {
            "id": 5,
            "product": {
                "id": 33,
                "name": "Stratus",
                "price": 1199.91,
                "number_sold": 0,
                "description": "2001 Dodge",
                "quantity": 1,
                "created_date": "2019-04-06",
                "location": "Tianning",
                "image_path": null,
                "average_rating": 0
            }
        },
        {
            "id": 6,
            "product": {
                "id": 71,
                "name": "Sebring",
                "price": 1045.66,
                "number_sold": 0,
                "description": "1999 Chrysler",
                "quantity": 4,
                "created_date": "2019-05-18",
                "location": "Namibe",
                "image_path": null,
                "average_rating": 0
            }
        }
    ],
    "size": 3
}


## Related Issues

- Fixes #24 