### PR TITLE
Bug: Can't remove an item from the cart #20: FIXED

### DIFF
--- a/bangazonapi/views/lineitem.py
+++ b/bangazonapi/views/lineitem.py
@@ -77,6 +77,7 @@ class LineItems(ViewSet):
         try:
             customer = Customer.objects.get(user=request.auth.user)
             order_product = OrderProduct.objects.get(pk=pk, order__customer=customer)
+            order_product.delete()
 
             return Response({}, status=status.HTTP_204_NO_CONTENT)
 


### PR DESCRIPTION
## Changes

- Added line 80 to `views/lineitem.py` destroy method to successfully delete line item from cart

## Testing

- [ ] Run migrations
- [ ] Run test suite
- [ ] Seed database
- [ ] Run server
- [ ] DELETE lineitems/4
- [ ] GET lineitems/4
- [ ] Test passes successfully if 404 returned and the following body
{
    "message": "OrderProduct matching query does not exist."
} 


## Related Issues

- Fixes #20 