### PR TITLE
Bug: Payment type info is incorrect #19: FIXED

### DIFF
--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -34,8 +34,8 @@ class Payments(ViewSet):
         new_payment = Payment()
         new_payment.merchant_name = request.data["merchant_name"]
         new_payment.account_number = request.data["account_number"]
-        new_payment.expiration_date = request.data["create_date"]
-        new_payment.create_date = request.data["expiration_date"]
+        new_payment.expiration_date = request.data["expiration_date"]
+        new_payment.create_date = request.data["create_date"]
         customer = Customer.objects.get(user=request.auth.user)
         new_payment.customer = customer
         new_payment.save()


### PR DESCRIPTION
## Changes

- Modified lines 37 and 38 of `views/paymenttype.py` so that the correct request data was stored for the expiration_date and create_date when a customer submits a new payment type.

## Testing

- [ ] Run migrations
- [ ] Run test suite
- [ ] Seed database
- [ ] Run server
- [ ] POST Create a payment type
- [ ] Test passes successfully if a 201 status is returned and the expiration_date and create_date data sent in the POST body corresponds with the newly created and returned payment type expiration_date and create_date


## Related Issues

- Fixes #19 