### PR TITLE
Bug: All payment types are being returned #18: FIXED

### DIFF
--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -19,7 +19,7 @@ class PaymentSerializer(serializers.HyperlinkedModelSerializer):
             view_name='payment',
             lookup_field='id'
         )
-        fields = ('id', 'url', 'merchant_name', 'account_number',
+        fields = ('id', 'customer', 'url', 'merchant_name', 'account_number',
                   'expiration_date', 'create_date')
 
 
@@ -81,10 +81,10 @@ class Payments(ViewSet):
         """Handle GET requests to payment type resource"""
         payment_types = Payment.objects.all()
 
-        customer_id = self.request.query_params.get('customer', None)
+        customer = Customer.objects.get(user=request.auth.user)
 
-        if customer_id is not None:
-            payment_types = payment_types.filter(customer__id=customer_id)
+        if customer is not None:
+            payment_types = payment_types.filter(customer__id=customer.id)
 
         serializer = PaymentSerializer(
             payment_types, many=True, context={'request': request})


### PR DESCRIPTION
## Changes

- Added 'customer' to fields of PaymentSerializer on line 22 of `views/paymenttype.py`
- Added changes to lines 84-87 of `views/paymenttype.py` so that the list method filters for the customer id of the authenticated user rather than the customer id already on the payment type.

## Testing

- [ ] Run migrations
- [ ] Run test suite
- [ ] Seed database
- [ ] Run server
- [ ] GET Get all payment types
- [ ] Test passes successfully if 200 status and only the payment types of Customer 4 are returned

## Related Issues

- Fixes #18 