### PR TITLE
Bug: Incorrect result for minimum products sold #21: FIXED

### DIFF
--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -268,7 +268,7 @@ class Products(ViewSet):
 
         if number_sold is not None:
             def sold_filter(product):
-                if product.number_sold <= int(number_sold):
+                if product.number_sold >= int(number_sold):
                     return True
                 return False
 


### PR DESCRIPTION
## Changes

- Changed line 271 of `views/product.py` to compare if the product's number_sold property is greater than or equal to the number_sold query param

## Testing

- [ ] Run migrations
- [ ] Run test suite
- [ ] Seed database
- [ ] Run Server
- [ ] GET products that have sold 2 or more
   (note: checking with a query param of 20 like the issue ticket originally specifies will not work because no product has been 
    sold that number of times.  2 is the most times any product has been sold.)
- [ ] The test passes successfully if a 200 response and only the product with id 50 is returned


## Related Issues

- Fixes #21 