### PR TITLE
Bug: Products keep getting added to the last, closed order #23: FIXED

### DIFF
--- a/bangazonapi/views/order.py
+++ b/bangazonapi/views/order.py
@@ -104,7 +104,7 @@ class Orders(ViewSet):
         """
         customer = Customer.objects.get(user=request.auth.user)
         order = Order.objects.get(pk=pk, customer=customer)
-        order.payment_type = request.data["payment_type"]
+        order.payment_type = Payment.objects.get(pk=request.data["payment_type"])
         order.save()
 
         return Response({}, status=status.HTTP_204_NO_CONTENT)

--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -233,7 +233,7 @@ class Profile(ViewSet):
             """
 
             try:
-                open_order = Order.objects.get(customer=current_user)
+                open_order = Order.objects.get(customer=current_user, payment_type__isnull=True)
                 print(open_order)
             except Order.DoesNotExist as ex:
                 open_order = Order()


### PR DESCRIPTION
## Changes

- Changed line 107 of `views/order.py` to assign a payment instance to the payment_type property of an updated order
- Changed line 236 of `views/profile.py` to not return any orders if the payment_type property of the customer's order is not null

## Testing

Description of how to test code...

- [ 1] Run migrations
- [ 2] Run test suite
- [ 3] Seed database
- [ 4] Run server
- [ 5] POST Create a payment type, but change the authorization token to 9ba45f09651c5b0c404f37a2d2572c026c14669c
- [ 6] POST Add item to cart
- [ 7] GET lineitems/{id} of new line item returned from POST in step 6
- [ 8] send a PUT request to the order id of the line item returned in step 7 that will add the payment type created in step 5 to the order
- [ 9]POST Add item to cart
- [ 10] GET orders
- If test passes successfully, the item added to the cart in step 9 should have been added to a newly created order


## Related Issues

- Fixes #23 