### PR TITLE
Bug: Same user profile always returned #22: FIXED

### DIFF
--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -81,7 +81,7 @@ class Profile(ViewSet):
             }
         """
         try:
-            current_user = Customer.objects.get(user=4)
+            current_user = Customer.objects.get(user=request.auth.user)
             current_user.recommends = Recommendation.objects.filter(recommender=current_user)
 
             serializer = ProfileSerializer(


### PR DESCRIPTION
## Changes

- Changed line 84 of `views/profile.py` to define the current user as the authenticated user rather than user 4

## Testing

- [ ] Run migrations
- [ ] Run test suite
- [ ] Seed database
- [ ] Run server
- [ ] GET user profile with the authentication token 9ba45f09651c5b0c404f37a2d2572c026c14669c
- [ ] GET user profile with the authentication token 9ba45f09651c5b0c404f37a2d2572c026c146690
- Passes tests successfully if the first user profile returned belongs to Brenda Long, and the second belongs to Steve Brownlee

## Related Issues

- Fixes #22 