### PR TITLE
REPORT: Incomplete orders #3

### DIFF
--- a/bangazonreports/templates/orders/incomplete_orders.html
+++ b/bangazonreports/templates/orders/incomplete_orders.html
@@ -1,0 +1,17 @@
+{% load static %}
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Bangazon Reports</title>
+  </head>
+  <body>
+    <h1>Incomplete Orders</h1>
+
+    {% for order in incomplete_orders_list %}
+        <h2>Order: {{ order.order_id }}</h2>
+        <div>Customer: {{ order.customer_name }}</div>
+        <div>Total cost of all order items: {{ order.order_total_cost|stringformat:".2f" }}</div>
+    {% endfor %}
+  </body>
+</html>

--- a/bangazonreports/urls.py
+++ b/bangazonreports/urls.py
@@ -1,6 +1,8 @@
 from django.urls import path
 from .views import customer_favorite_sellers_list
+from .views import incomplete_orders_list
 
 urlpatterns = [
     path('reports/favoritesellers', customer_favorite_sellers_list),
+    path('reports/incompleteorders', incomplete_orders_list),
 ]

--- a/bangazonreports/views/__init__.py
+++ b/bangazonreports/views/__init__.py
@@ -1,2 +1,3 @@
 from .connection import Connection
 from .users.favorited_sellers_by_customer import customer_favorite_sellers_list
+from .orders.incomplete_orders import incomplete_orders_list

--- a/bangazonreports/views/orders/incomplete_orders.py
+++ b/bangazonreports/views/orders/incomplete_orders.py
@@ -1,0 +1,53 @@
+"""Module for generating games by user report"""
+import sqlite3
+from django.shortcuts import render
+from bangazonreports.views import Connection
+
+
+def incomplete_orders_list(request):
+    """Function to build an HTML report showing all users that have favorited a seller,
+        including the favorited sellers"""
+
+    if request.method == 'GET':
+        with sqlite3.connect(Connection.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            db_cursor = conn.cursor()
+            db_cursor.execute("""
+                SELECT
+                    u.first_name || ' ' || u.last_name customer_name,
+                    o.id order_id,
+                    SUM(p.price) order_total_cost
+                FROM
+                    auth_user u
+                JOIN
+                    bangazonapi_customer c ON c.user_id = u.id
+                JOIN
+                    bangazonapi_order o ON o.customer_id = c.id
+                JOIN
+                    bangazonapi_orderproduct op ON op.order_id = o.id
+                JOIN
+                    bangazonapi_product p ON p.id = op.product_id
+                WHERE
+                    o.payment_type_id IS NULL
+                GROUP BY
+                    order_id;
+            """)
+
+            dataset = db_cursor.fetchall()
+
+            incomplete_orders = []
+
+            for row in dataset:
+                incomplete_order = {}
+                incomplete_order["order_id"] = row["order_id"]
+                incomplete_order["customer_name"] = row["customer_name"]
+                incomplete_order["order_total_cost"] = row["order_total_cost"]
+                incomplete_orders.append(incomplete_order)
+
+
+        template = 'orders/incomplete_orders.html'
+        context = {
+            'incomplete_orders_list': incomplete_orders
+        }
+
+        return render(request, template, context)


### PR DESCRIPTION
## Changes

- Added `incomplete_orders.py` to bangazonreports/views/orders
- Added `incomplete_orders.html` to bangazonreports/templates/orders
- Added path to `incomplete_orders.html` in `bangazonreports/urls.py`

## Testing

- [ ] Run migrations
- [ ] Run test suite
- [ ] Seed database
- [ ] Run server
- [ ] Open web browser and go to "http://localhost:8000/reports/incompleteorders"
- [ ] Test successfully passes if:
- [ ] 1. A header that reads "Incomplete Orders" displays at the top
- [ ] 2. Each incomplete order is displayed below with a header that reads "Order: {order_id}", and the customer's name and the total cost of all order items displayed underneath


## Related Issues

- Fixes #3 