### PR TITLE
Feature: Users can favorite a seller #13

### DIFF
--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -255,60 +255,94 @@ class Profile(ViewSet):
 
         return Response({}, status=status.HTTP_405_METHOD_NOT_ALLOWED)
 
-    @action(methods=['get'], detail=False)
+    @action(methods=['get', 'post'], detail=False)
     def favoritesellers(self, request):
-        """
-        @api {GET} /profile/favoritesellers GET favorite sellers
-        @apiName GetFavoriteSellers
-        @apiGroup UserProfile
+        """Favorite seller manipulations"""
 
-        @apiHeader {String} Authorization Auth token
-        @apiHeaderExample {String} Authorization
-            Token 9ba45f09651c5b0c404f37a2d2572c026c146611
+        if request.method == "GET":
+            """
+            @api {GET} /profile/favoritesellers GET favorite sellers
+            @apiName GetFavoriteSellers
+            @apiGroup UserProfile
 
-        @apiSuccess (200) {id} id Favorite id
-        @apiSuccess (200) {Object} seller Favorited seller
-        @apiSuccess (200) {String} seller.url Seller URI
-        @apiSuccess (200) {String} seller.phone_number Seller phone number
-        @apiSuccess (200) {String} seller.address Seller address
-        @apiSuccess (200) {String} seller.user Seller user profile URI
-        @apiSuccessExample {json} Success
-            [
-                {
-                    "id": 1,
-                    "seller": {
-                        "url": "http://localhost:8000/customers/5",
-                        "phone_number": "555-1212",
-                        "address": "100 Endless Way",
-                        "user": "http://localhost:8000/users/6"
-                    }
-                },
-                {
-                    "id": 2,
-                    "seller": {
-                        "url": "http://localhost:8000/customers/6",
-                        "phone_number": "555-1212",
-                        "address": "100 Dauntless Way",
-                        "user": "http://localhost:8000/users/7"
-                    }
-                },
-                {
-                    "id": 3,
-                    "seller": {
-                        "url": "http://localhost:8000/customers/7",
-                        "phone_number": "555-1212",
-                        "address": "100 Indefatiguable Way",
-                        "user": "http://localhost:8000/users/8"
-                    }
-                }
-            ]
-        """
-        customer = Customer.objects.get(user=request.auth.user)
-        favorites = Favorite.objects.filter(customer=customer)
+            @apiHeader {String} Authorization Auth token
+            @apiHeaderExample {String} Authorization
+                Token 9ba45f09651c5b0c404f37a2d2572c026c146611
 
-        serializer = FavoriteSerializer(
-            favorites, many=True, context={'request': request})
-        return Response(serializer.data)
+            @apiSuccess (200) {id} id Favorite id
+            @apiSuccess (200) {Object} seller Favorited seller
+            @apiSuccess (200) {String} seller.url Seller URI
+            @apiSuccess (200) {String} seller.phone_number Seller phone number
+            @apiSuccess (200) {String} seller.address Seller address
+            @apiSuccess (200) {String} seller.user Seller user profile URI
+            @apiSuccessExample {json} Success
+                [
+                    {
+                        "id": 1,
+                        "seller": {
+                            "url": "http://localhost:8000/customers/5",
+                            "phone_number": "555-1212",
+                            "address": "100 Endless Way",
+                            "user": "http://localhost:8000/users/6"
+                        }
+                    },
+                    {
+                        "id": 2,
+                        "seller": {
+                            "url": "http://localhost:8000/customers/6",
+                            "phone_number": "555-1212",
+                            "address": "100 Dauntless Way",
+                            "user": "http://localhost:8000/users/7"
+                        }
+                    },
+                    {
+                        "id": 3,
+                        "seller": {
+                            "url": "http://localhost:8000/customers/7",
+                            "phone_number": "555-1212",
+                            "address": "100 Indefatiguable Way",
+                            "user": "http://localhost:8000/users/8"
+                        }
+                    }
+                ]
+            """
+            customer = Customer.objects.get(user=request.auth.user)
+            favorites = Favorite.objects.filter(customer=customer)
+
+            serializer = FavoriteSerializer(
+                favorites, many=True, context={'request': request})
+            return Response(serializer.data)
+
+        if request.method == "POST":
+            """
+            @api {POST} /profile/favoritesellers POST new favorite seller
+            @apiName AddFavoriteSeller
+            @apiGroup UserProfile
+
+            @apiHeader {String} Authorization Auth token
+            @apiHeaderExample {String} Authorization
+                Token 9ba45f09651c5b0c404f37a2d2572c026c146694
+
+            @apiParam {id} customer Seller Id of the favorite seller
+            @apiParamExample {json} Input
+            {
+                "seller": 6
+            }
+
+            @apiSuccessExample {json} Success
+            Response -- JSON serialized favorite seller instance
+            HTTP/1.1 201 Created
+            """
+
+            favorite = Favorite()
+            favorite.customer = Customer.objects.get(user=request.auth.user)
+            favorite.seller = Customer.objects.get(id=request.data["seller"])
+            favorite.save()
+
+            serializer = FavoriteSerializer(
+                favorite, many=False, context={'request': request})
+
+            return Response(serializer.data, status=status.HTTP_201_CREATED)
 
 
 class LineItemSerializer(serializers.HyperlinkedModelSerializer):


### PR DESCRIPTION
## Changes

- Added a POST method to the favoritesellers @action in `bangazonapi/views/profile.py`

## Requests / Responses

**Request**

POST `/profile/favoritesellers` Creates a new favorite seller

```json
{
    "seller": 6
}
```

**Response**

HTTP/1.1 201 OK

```json
{
    "id": 4,
        "seller": {
            "id": 6,
            "url": "http://localhost:8000/customers/6",
            "user": {
                "first_name": "Jisie",
                "last_name": "David",
                "username": "jisie"
            }
        }
}
```

## Testing

- [ ] Run migrations
- [ ] Run test suite
- [ ] Seed database
- [ ] Run server
- [ ] Set Authorization Token to 9ba45f09651c5b0c404f37a2d2572c026c146694
- [ ] POST the following body to profile/favoritesellers:
{
   "seller": 6
}
- [ ] Test passes successfully is 201 status code returned and the following favorite seller object
{
    "id": 4,
    "seller": {
        "id": 6,
        "url": "http://localhost:8000/customers/6",
        "user": {
            "first_name": "Jisie",
            "last_name": "David",
            "username": "jisie"
        }
    }
}


## Related Issues

- Fixes #13 